### PR TITLE
emit focus_lost event, add events.FOCUS_LOST

### DIFF
--- a/core/events.lua
+++ b/core/events.lua
@@ -399,7 +399,7 @@ end)
 
 -- Set event constants.
 for _, v in pairs(_SCINTILLA.events) do M[v[1]:upper()] = v[1] end
-local textadept_events = {'appleevent_odoc','buffer_after_switch','buffer_before_switch','buffer_deleted','buffer_new','csi','command_text_changed','error','find','find_text_changed','focus','initialized','keypress','menu_clicked','mouse','quit','replace','replace_all','reset_after','reset_before','resume','suspend', 'tab_clicked','view_after_switch','view_before_switch','view_new'}
+local textadept_events = {'appleevent_odoc','buffer_after_switch','buffer_before_switch','buffer_deleted','buffer_new','csi','command_text_changed','error','find','find_text_changed','focus','focus_lost','initialized','keypress','menu_clicked','mouse','quit','replace','replace_all','reset_after','reset_before','resume','suspend','tab_clicked','view_after_switch','view_before_switch','view_new'}
 for _, v in pairs(textadept_events) do M[v:upper()] = v end
 
 return M

--- a/docs/api.md
+++ b/docs/api.md
@@ -3982,6 +3982,12 @@ Emitted when the text in the "Find" field of the Find & Replace Pane
 Emitted when Textadept receives focus.
   This event is never emitted when Textadept is running in the terminal.
 
+<a id="events.FOCUS_LOST"></a>
+#### `events.FOCUS_LOST` (string)
+
+Emitted when Textadept loses focus.
+  This event is never emitted when Textadept is running in the terminal.
+
 <a id="events.INDICATOR_CLICK"></a>
 #### `events.INDICATOR_CLICK` (string)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ development.**
 [donate]: https://gum.co/textadept
 [book]: book.html
 
+### Next
+
+Changes:
+
+* New [`events.FOCUS_LOST`][] event for when Textadept's window loses focus.
+
 ### 11.0 beta 2 (01 Nov 2020)
 
 Please see the [10 to 11 migration guide][] for upgrading from Textadept 10 to

--- a/modules/lua/ta_api
+++ b/modules/lua/ta_api
@@ -77,6 +77,7 @@ FIND_WHOLEWORD buffer.FIND_WHOLEWORD (number, Read-only)\n
 FIND_WORDSTART buffer.FIND_WORDSTART (number, Read-only)\n
 FIND_WRAPPED events.FIND_WRAPPED (string)\nEmitted when a text search wraps (passes through the beginning of the\nbuffer), either from bottom to top (when searching for a next occurrence),\nor from top to bottom (when searching for a previous occurrence).\nThis is useful for implementing a more visual or audible notice when a\nsearch wraps in addition to the statusbar message.
 FOCUS events.FOCUS (string)\nEmitted when Textadept receives focus.\nThis event is never emitted when Textadept is running in the terminal.
+FOCUS_LOST events.FOCUS_LOST (string)\nEmitted when Textadept loses focus.\nThis event is never emitted when Textadept is running in the terminal.
 FOLDACTION_CONTRACT view.FOLDACTION_CONTRACT (number, Read-only)\n
 FOLDACTION_EXPAND view.FOLDACTION_EXPAND (number, Read-only)\n
 FOLDACTION_TOGGLE view.FOLDACTION_TOGGLE (number, Read-only)\n

--- a/src/textadept.c
+++ b/src/textadept.c
@@ -2284,6 +2284,7 @@ static GtkWidget *new_findbox() {
  * losing focus or the application is quitting.
  */
 static bool focus_lost(GtkWidget *widget, GdkEvent *_, void *L) {
+  if (widget == window) emit(lua, "focus_lost", -1);
   if (widget == window && command_entry_focused) return true; // halt
   if (widget != command_entry || closing) return false;
   return (emit(L, "keypress", LUA_TNUMBER, GDK_KEY_Escape, -1), false);


### PR DESCRIPTION
Expose focus_lost event to lua. A handler was already registered in gtk, so this is a small change.
This change enables autosave on focus lost, a convenient, [previously requested](https://news.ycombinator.com/item?id=15363832) feature.