### PR TITLE
Fix OpenBSD build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,8 @@
 
 # Base flags and options.
 
-CFLAGS := -Os
-CXXFLAGS := -Os -std=c++17
+CFLAGS += -Os -std=c11
+CXXFLAGS += -Os -std=c++17
 WGET = wget -O $@
 
 # Define these once for speed and reference them later.


### PR DESCRIPTION
Builds v11.4 using the following command:

```
CFLAGS=-I/usr/local/include gmake CC=clang CXX=clang LDLIBS="-L/usr/local/lib -lm -liconv -lstdc++" GTK2=1
```

We need to override some values directly in the command, because some dependency makefiles also set `$(CC)` and such, which causes problems when linking.

Since the changes to `textadept.c` are pretty minimal (use `realpath` to get `textadept_home` and change an include), I'd recommend re-adding support for OpenBSD. Just need to document that build command somewhere :)