### PR TITLE
Add numpad enter as hotkey when searching

### DIFF
--- a/src/textadept_qt.cpp
+++ b/src/textadept_qt.cpp
@@ -668,7 +668,7 @@ protected:
 	bool eventFilter(QObject *watched, QEvent *event) override {
 		if (event->type() != QEvent::KeyPress) return false;
 		auto keyEvent = static_cast<QKeyEvent *>(event);
-		if (keyEvent->key() != Qt::Key_Return) return false;
+		if (keyEvent->key() != Qt::Key_Return && keyEvent->key() != Qt::Key_Enter) return false;
 		auto button = (keyEvent->modifiers() & Qt::ShiftModifier) == 0 ?
 			(watched == ta->ui->findCombo ? ta->ui->findNext : ta->ui->replace) :
 			(watched == ta->ui->findCombo ? ta->ui->findPrevious : ta->ui->replaceAll);


### PR DESCRIPTION
Adds the numpad enter key alongside the return key to advance an open search.

I think this used to work in past versions of Textadept but seems to have been missed during the update to Qt.