### PR TITLE
Support Fossil on non-Windows Systems

### DIFF
--- a/core/file_io.lua
+++ b/core/file_io.lua
@@ -331,7 +331,7 @@ end
 --- Map of version control files to their lfs modes.
 local vcs = {
 	['.bzr'] = 'directory', ['.git'] = 'directory', ['.hg'] = 'directory', ['.svn'] = 'directory',
-	_FOSSIL_ = 'file'
+	_FOSSIL_ = 'file', ['.fslckout'] = 'file'
 }
 
 --- Returns the root directory of the project that contains filesystem path *path*.


### PR DESCRIPTION
Fossil uses the file `_FOSSIL_` on Windows but on all other operating systems it prefers `.fslckout` (either will work but those are the names used by the software when you create checkouts).

You can see this documented in the [Fossil Glossary](https://fossil-scm.org/home/doc/trunk/www/glossary.md) in the "Checkout" section where it says:

> Check-out directories are associated with the repos they were created from by settings stored in the check-out directory. This is in the .fslckout file on POSIX type systems, but for historical compatibility reasons, it’s called _FOSSIL_ by native Windows builds of Fossil.

Basically the use of `_FOSSIL_` on Windows is for historical windows file systems that don't support more than three characters as an extension.