### PR TITLE
Do not override the user passed style on Windows

### DIFF
--- a/src/textadept_qt.cpp
+++ b/src/textadept_qt.cpp
@@ -758,9 +758,6 @@ public:
 		connect(this, &QApplication::aboutToQuit, this, &close_textadept);
 		// There is a bug in Qt where a tab scroll button could have focus at this time.
 		if (!SCI(focused_view)->hasFocus()) SCI(focused_view)->setFocus();
-#if _WIN32
-		setStyle(QStyleFactory::create("Fusion"));
-#endif
 	}
 	~Application() override {
 		if (inited) delete ta;
@@ -780,4 +777,9 @@ private:
 	bool inited = false;
 };
 
-int main(int argc, char *argv[]) { return Application{argc, argv}.exec(); }
+int main(int argc, char *argv[]) {
+#if _WIN32
+	QApplication::setStyle(QStyleFactory::create("Fusion"));
+#endif
+	return Application{argc, argv}.exec();
+}


### PR DESCRIPTION
Hi Mitchell,

This is a fix to allow a user to pass a Qt style on Windows. I know you're using the Qt's Fusion style by default on Windows for good reasons, but I quite liked being able to use the WindowsVista and the (admittedly poor) Windows11 styles. The force to Qt Fusion starting in Textadept 12.5 means the user can't pass the `-style` parameter. Luckily this can be fixed by setting the style before starting the Qt exec loop as said here:

> [You can call QApplication::setStyle() at any time, but by calling it before the constructor, you ensure that the user's preference, set using the -style command-line option, is respected.](https://doc.qt.io/qt-6/qstyle.html)

I also had quite a time trying to build on Windows using CMake GUI and VS2022. Just for documentation's sake my issues were:

- CMake (4.1.2) refused to autodetect my Qt install so I had to add "C:Qt\qt_ver\msvc2022_64\" to the CMAKE_PREFIX_PATH variable (I used Qt 6.8.3 to test).
- Needed to add the patch tool to my path so CMake could apply the patches (I used the one provided with Windows Git).
- The Qt5 Compat module must also be installed.
- Needed to add INSTALL as a target in Visual Studio under Configuration Manager is it wasn't configured to "build" it by default.
- Sometimes the CMAKE_INSTALL_PREFIX needs to be set to `build_dir\install` as it tried to default to `Program Files` which the install scripts don't work with.
- This morning when I tried to build again with Qt 6.9.3 ftp.gnu.org was down so CMake couldn't download iconv, from Googling it seems to be a somewhat common occurrence 😞 turns out they're intent on shutting down FTP access at some point anyways.

Thanks!