### PR TITLE
Stop qt menus appearing as separate windows.

### DIFF
--- a/src/textadept_qt.cpp
+++ b/src/textadept_qt.cpp
@@ -314,6 +314,16 @@ void *read_menu(lua_State *L, int index) {
 		}
 		lua_pop(L, 1); // label
 	}
+	// mark submenus as popups
+	for (auto action : menu->actions()) {
+		if (action->menu()) {
+			QObject::connect(action->menu(), &QMenu::aboutToShow, menu, [action, menu] {
+				if (action->menu()->windowHandle()) {
+					action->menu()->windowHandle()->setTransientParent(menu->windowHandle());
+				}
+			});
+		}
+	}
 	return menu;
 }
 
@@ -327,6 +337,12 @@ void set_menubar(lua_State *L, int index) {
 	for (size_t i = 1; i <= lua_rawlen(L, index); lua_pop(L, 1), i++) {
 		auto menu = static_cast<QMenu *>(lua_rawgeti(L, index, i), lua_touserdata(L, -1));
 		ta->menuBar()->addMenu(menu); // menubar does not take ownership
+		// mark top-level menus as popups
+		QObject::connect(menu, &QMenu::aboutToShow, ta->menuBar(), [menu] {
+			if (menu->windowHandle()) {
+				menu->windowHandle()->setTransientParent(ta->windowHandle());
+			}
+		});
 	}
 	ta->menuBar()->setVisible(lua_rawlen(L, index) > 0);
 }


### PR DESCRIPTION
Copied blindly from [libplasma MR 239](https://invent.kde.org/plasma/libplasma/-/commit/27299d1405f6d26f6fa62b3337ab23e0924c1604) which has since moved to `src/plasmaquick/plasmoid/containmentitem.cpp` but the two `setTransientParent()` calls are still in place there so it must still be doing something.

Please take with a huge grain of salt because I don't actually know Qt. In particular, I don't totally understand what the `context` argument to `QObject::connect` does, or why QMenu and QMenuBar don't take care of this for you. Also maybe don't let me interfere with your qt6 migration if you're already tearing stuff up for that.

Fixes #592.