### PR TITLE
Prevent xsel output being shown at startup

### DIFF
--- a/modules/textadept/clipboard.lua
+++ b/modules/textadept/clipboard.lua
@@ -15,7 +15,7 @@ local M = {}
 --	supplies these commands. On Ubuntu for example, the `xsel` and `wl-clipboard` packages,
 --	respectively, supply these commands.
 M.paste_command = OSX and 'pbpaste' or WIN32 and 'powershell get-clipboard' or 'xsel -b -o'
-if not OSX and not WIN32 and not os.execute('xsel') then M.paste_command = 'wl-paste -n' end
+if not OSX and not WIN32 and not os.execute('xsel > /dev/null') then M.paste_command = 'wl-paste -n' end
 
 --- The command to modify the system clipboard's contents.
 -- The default values are:
@@ -26,7 +26,7 @@ if not OSX and not WIN32 and not os.execute('xsel') then M.paste_command = 'wl-p
 --	packages, respectively, supply these commands.
 --	Note: this command should not fork.
 M.copy_command = OSX and 'pbcopy' or WIN32 and 'clip' or 'xsel -n -b -i'
-if not OSX and not WIN32 and not os.execute('xsel') then M.copy_command = 'wl-copy -f' end
+if not OSX and not WIN32 and not os.execute('xsel > /dev/null') then M.copy_command = 'wl-copy -f' end
 
 local get_scintilla_clipboard = ui.get_clipboard_text
 -- Documentation is in core/ui.lua.

--- a/modules/textadept/clipboard.lua
+++ b/modules/textadept/clipboard.lua
@@ -15,7 +15,7 @@ local M = {}
 --	supplies these commands. On Ubuntu for example, the `xsel` and `wl-clipboard` packages,
 --	respectively, supply these commands.
 M.paste_command = OSX and 'pbpaste' or WIN32 and 'powershell get-clipboard' or 'xsel -b -o'
-if not OSX and not WIN32 and not os.execute('xsel > /dev/null') then M.paste_command = 'wl-paste -n' end
+if not OSX and not WIN32 and not os.execute('xsel > /dev/null 2>&1') then M.paste_command = 'wl-paste -n' end
 
 --- The command to modify the system clipboard's contents.
 -- The default values are:
@@ -26,7 +26,7 @@ if not OSX and not WIN32 and not os.execute('xsel > /dev/null') then M.paste_com
 --	packages, respectively, supply these commands.
 --	Note: this command should not fork.
 M.copy_command = OSX and 'pbcopy' or WIN32 and 'clip' or 'xsel -n -b -i'
-if not OSX and not WIN32 and not os.execute('xsel > /dev/null') then M.copy_command = 'wl-copy -f' end
+if not OSX and not WIN32 and not os.execute('xsel > /dev/null 2>&1') then M.copy_command = 'wl-copy -f' end
 
 local get_scintilla_clipboard = ui.get_clipboard_text
 -- Documentation is in core/ui.lua.


### PR DESCRIPTION
Hi Mitchell,

In textadept-curses it would sometimes show text I'd recently typed in other apps for a brief moment at startup. I was a bit freaked but it turns out it was xsel thinking the text is highlighted and outputting it into the terminal Textadept is running in with the os.execute call. By redirecting it's output to `/dev/null` startup is much cleaner as you only need the exit status and also stops any intentionally highlighted text being shown at startup.

Thanks,

Jamie