### PR TITLE
Enable SGR mouse mode for control beyond 223 columns

### DIFF
--- a/core/ui.lua
+++ b/core/ui.lua
@@ -338,8 +338,14 @@ end)
 -- Handle mouse events and functionality in the terminal version.
 if CURSES then
 	if not WIN32 then
-		local function enable_mouse() io.stdout:write("\x1b[?1002h"):flush() end
-		local function disable_mouse() io.stdout:write("\x1b[?1002l"):flush() end
+		local function enable_mouse()
+			io.stdout:write("\x1b[?1002h"):flush()
+			io.stdout:write("\x1b[?1006h"):flush()
+		end
+		local function disable_mouse()
+			io.stdout:write("\x1b[?1002l"):flush()
+			io.stdout:write("\x1b[?1006l"):flush()
+		end
 		events.connect(events.INITIALIZED, enable_mouse)
 		events.connect(events.SUSPEND, disable_mouse)
 		events.connect(events.RESUME, enable_mouse)


### PR DESCRIPTION
Hi Mitchell,

This enables SGR mouse mode to allow mouse tracking beyond 223 columns.
This is handy to allow the mouse to use the scrollbar if the terminal is wider than that, or select on long lines over 223 characters.

Thanks,

Jamie