### PR TITLE
Fix UTF-8 charset on Windows

### DIFF
--- a/src/textadept_qt.cpp
+++ b/src/textadept_qt.cpp
@@ -47,7 +47,10 @@ const char *get_charset() {
 	// Ask Windows for its charset encoding because QTextCodec returns "System", which is not a
 	// valid iconv encoding.
 	static char codepage[8];
-	return (sprintf(codepage, "CP%d", GetACP()), codepage);
+	sprintf(codepage, "CP%d", GetACP());
+	// CP65001 is the Windows internal code for UTF-8, but iconv doesn't understand this.
+	if (!strcmp(codepage, "CP65001")) strcpy(codepage, "UTF-8");
+	return codepage;
 #endif
 }
 


### PR DESCRIPTION
Fixes issue #660 

I don't know whether you want to accept this, or maybe [patch iconv instead](https://gitweb.git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=lib/encodings.def;h=41d8063e6b1997c5ac30f05e128d9b7bb5c40cde;hb=HEAD#l62)?
There's a discussion in MSYS2's repo about a similar problem with GDB package: https://github.com/msys2/MINGW-packages/issues/14947

It seems enabling it in iconv comes with a host of other backwards compatibility issues which is why it's not enabled by default.