### PR TITLE
Select theme dialog added

### DIFF
--- a/core/view.lua
+++ b/core/view.lua
@@ -60,6 +60,31 @@ local function set_theme(view, name, env)
 	view:set_styles()
 end
 
+local function select_theme(view)
+    local themes = {}
+    for _, dir in ipairs{_USERHOME .. '/themes', _HOME .. '/themes'} do  
+        if lfs.attributes(dir, 'mode') == 'directory' then
+            for file in lfs.dir(dir) do
+                local name = file:match('^(.+)%.lua$')
+                if name then themes[#themes + 1] = name end
+            end
+        end
+    end
+    table.sort(themes)
+    -- Remove duplicates.
+    local i = 1
+    while i < #themes do 
+        if themes[i] == themes[i + 1] then
+            table.remove(themes, i + 1)
+        else
+            i = i + 1
+        end
+    end
+    local i = ui.dialogs.list{title = _L['Select Theme'], items = themes}
+    if i then view:set_theme(themes[i]) end
+end
+
+
 --- Metatable for `view.styles`, whose documentation is in core/buffer.lua.
 local styles_mt = {
 	__index = function(t, k) return type(k) == 'string' and t[k:match('^(.+)[_%.]')] or rawget(t, k) end,
@@ -71,5 +96,5 @@ local styles_mt = {
 events.connect(events.VIEW_NEW, function()
 	local view = buffer ~= ui.command_entry and view or ui.command_entry
 	view.colors, view.styles = {}, setmetatable({}, styles_mt)
-	view.set_styles, view.set_theme = set_styles, set_theme
+	view.set_styles, view.set_theme, view.select_theme = set_styles, set_theme, select_theme
 end, 1)

--- a/modules/textadept/menu.lua
+++ b/modules/textadept/menu.lua
@@ -422,6 +422,8 @@ local default_menubar = {
 					buffer.VS_RECTANGULARSELECTION | buffer.VS_USERACCESSIBLE or 0
 			end
 		}, SEPARATOR, --
+		{_L['Select theme'], function() view:select_theme() end},
+		SEPARATOR,
 		{_L['Zoom In'], view.zoom_in}, --
 		{_L['Zoom Out'], view.zoom_out}, --
 		{_L['Reset Zoom'], function() view.zoom = 0 end}


### PR DESCRIPTION
This commit adds `view:select_theme()` function that displays a theme selection dialog containing the themes from the Textadept home and User home, allows to quickly set a theme.

This function is added as a new item in the View menu.

This feature follows the simple theme selection feature of other editors. However the selected theme doesn't get saved as default.

<img width="997" height="631" alt="Screenshot_textadept" src="https://github.com/user-attachments/assets/2ac79126-27aa-4676-9619-2e5c4fe20947" />

Hope you find this little feature useful.

Will probably need to add unit tests and translations.