### PR TITLE
Add URL_HASH to cmake content fetches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,44 +79,73 @@ set(deps_dir ${CMAKE_BINARY_DIR}/_deps)
 if(POLICY CMP0135) # CMake 3.24 adds DOWNLOAD_EXTRACT_TIMESTAMP to FetchContent_Declare()
 	cmake_policy(SET CMP0135 NEW)
 endif()
-function(fetch name url)
+function(fetch name url url_hash)
 	string(REGEX MATCH "[^/]+$" archive ${url})
 	list(FIND nightlies ${name} can_use_nightly)
 	if(NIGHTLY AND can_use_nightly GREATER -1)
 		string(REPLACE ${archive} default.zip url ${url}) # use nightly URL instead
-	elseif(EXISTS ${deps_dir}/${archive})
-		set(url file://${deps_dir}/${archive}) # use local archive instead of downloading
 	endif()
 	set(patch ${CMAKE_SOURCE_DIR}/src/${name}.patch)
 	if(EXISTS ${patch})
 		set(patch_command PATCH_COMMAND patch -N -p1 < ${patch})
 	endif()
-	FetchContent_Declare(${name} URL ${url} ${patch_command})
+
+    # ignore URL_HASH for nightly builds
+    if(NIGHTLY)
+        FetchContent_Declare(${name} URL ${url} ${patch_command})
+    else()
+        FetchContent_Declare(${name} URL ${url} URL_HASH SHA256=${url_hash} ${patch_command})
+    endif()
+
 	# Note: cannot FetchContent_MakeAvailable(${name}) here, as name must be a literal.
 endfunction()
-fetch(scintilla https://www.scintilla.org/scintilla563.tgz)
-fetch(scinterm https://github.com/orbitalquark/scinterm/archive/scinterm_6.0.zip)
-fetch(scintillua https://github.com/orbitalquark/scintillua/archive/b9986ecad77b1ea73d75bf1e82e6e0fd3b4958b1.zip)
-fetch(lua https://lua.org/ftp/lua-5.5.0.tar.gz)
-fetch(lpeg https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz)
-fetch(lfs https://github.com/keplerproject/luafilesystem/archive/v1_8_0.zip)
-fetch(regex https://github.com/orbitalquark/lua-std-regex/archive/1.0.zip)
-fetch(cdk https://github.com/ThomasDickey/cdk-snapshots/archive/refs/tags/t20260119.tar.gz)
-fetch(termkey https://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
-fetch(reproc https://github.com/DaanDeMeyer/reproc/archive/refs/tags/v14.2.5.zip)
+fetch(scintilla
+    https://www.scintilla.org/scintilla563.tgz
+    f64339c504960c5a95510e6c3306ab5e95f23abaf8aed82897e57bff78e74616)
+fetch(scinterm
+    https://github.com/orbitalquark/scinterm/archive/scinterm_6.0.zip
+    af65b064ed1486b715d91a6c7d6e290d01c74ba618b87cef21823f170ebda06e)
+fetch(scintillua
+    https://github.com/orbitalquark/scintillua/archive/b9986ecad77b1ea73d75bf1e82e6e0fd3b4958b1.zip
+    9ca802b0e06a24f410df9545d02802fff9eff2b5aa7254bc6e51173ed38feae6)
+fetch(lua
+    https://lua.org/ftp/lua-5.5.0.tar.gz
+    57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d)
+fetch(lpeg
+    https://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz
+    4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a)
+fetch(lfs
+    https://github.com/keplerproject/luafilesystem/archive/v1_8_0.zip
+    e3a6beca7a8a90522eed31db6ccdc5ed65a433826500c6862784e27671b9e18a)
+fetch(regex
+    https://github.com/orbitalquark/lua-std-regex/archive/1.0.zip
+    5b684a1ce7ea632a37aa4f98bcf265cd97d9d70c5998c56985295c6aa97e74e1)
+fetch(cdk
+    https://github.com/ThomasDickey/cdk-snapshots/archive/refs/tags/t20260119.tar.gz
+    0f3095d7983227c06d1d326a6c95e0255e944be8a0f9748174840bfb3edd0cb5)
+fetch(termkey
+    https://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz
+    6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
+fetch(reproc
+    https://github.com/DaanDeMeyer/reproc/archive/refs/tags/v14.2.5.zip
+    21b168c38adb22f4b48391d8193dbc3927f1f2e678c2058d6944a29b64acc6c9)
 FetchContent_MakeAvailable(scintilla scinterm lua lpeg lfs regex cdk termkey)
 if(POLICY CMP0169) # CMake 3.28 adds EXCLUDE_FROM_ALL to FetchContent_MakeAvailable()
 	cmake_policy(SET CMP0169 OLD)
 endif()
 FetchContent_Populate(scintillua) # do not import targets; only need Lua lexers
 if(WIN32)
-	fetch(pdcurses https://prdownloads.sourceforge.net/pdcurses/PDCurses-3.9.zip)
-	fetch(iconv https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz)
+	fetch(pdcurses
+        https://prdownloads.sourceforge.net/pdcurses/PDCurses-3.9.zip
+        5c2ccab1d8fbf7e2c82eac954444a6760eb949d47d6dc57e09f339d34a50ba79)
+	fetch(iconv https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz
+        8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313)
 	FetchContent_MakeAvailable(pdcurses iconv)
 endif()
 if(QT)
 	fetch(qtsingleapplication
-		https://github.com/qtproject/qt-solutions/archive/777e95ba69952f11eaec0adfb0cb987fabcdecb3.zip)
+		https://github.com/qtproject/qt-solutions/archive/777e95ba69952f11eaec0adfb0cb987fabcdecb3.zip
+        195f1fcabe80e711199517f20b916d603ea260b1a2d7abcc8ce980af67f3cc96)
 	FetchContent_MakeAvailable(qtsingleapplication)
 endif()
 if(CURSES)


### PR DESCRIPTION
Currently `CMakeLists.txt` does not check the hashes of archives for fetched dependencies. This is an issue for numerous reasons:
- It allows for supply-chain attacks, e.g. an existing archive is replaced with a malicious archive that has a different hash.
- It breaks some automated packing systems that cache archives with the expectation that the build system will automatically recognize them and not re-download them during configuration, e.g. Void Linux's `xbps-src`. 
- It forces us to manually skip re-downloads of archives, which is redundant given that `FetchContent` automatically provides said behavior when a `URL_HASH` is provided.

This PR refactors fetch() to use the optional `URL_HASH` parameter with `FetchContent_Declare()`, removes previous manual archive caching as CMake will automatically cache archives using the given `URL_HASH`, and updates existing fetch() calls with their corresponding hashes. Note that hashes are still ignored for `NIGHTLY` builds.