### PR TITLE
Fix select line keybinding

### DIFF
--- a/modules/textadept/keys.lua
+++ b/modules/textadept/keys.lua
@@ -362,7 +362,7 @@ keys.assign_platform_bindings{
 		'ctrl+M', 'cmd+M', {'ctrl+meta+m', 'meta+\n', 'ctrl+shift+\n'}
 	}, [textadept.editing.select_word] = {'ctrl+d', 'cmd+d', 'ctrl+d'},
 	[m('Edit/Select/Deselect Word')] = {'ctrl+alt+d', 'ctrl+cmd+d', 'meta+d'},
-	[textadept.editing.select_line] = {'ctrl+shift+l', 'cmd+shift+l', 'ctrl+alt+l'},
+	[textadept.editing.select_line] = {'ctrl+L', 'cmd+shift+l', 'ctrl+alt+l'},
 	[textadept.editing.select_paragraph] = {'ctrl+P', 'cmd+P', 'ctrl+meta+p'},
 	-- Selection.
 	[m('Edit/Selection/Upper Case Selection')] = {{'ctrl+U', 'ctrl+alt+U'}, 'cmd+U', 'ctrl+meta+u'},


### PR DESCRIPTION
Hi Mitchell, 

This keybinding has never worked since it was changed as the "shift" keybindings need to use the capital letter in the binding instead of shift. Didn't notice for a while because I had set my init.lua to use the old bindings. I can't test on macOS easily so that binding might need fixed too?

Thanks, Jamie